### PR TITLE
UTF-8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - all Parameters for alias-usage
 - allowing to pass an array of additional parameters to the `PostFinanceEPayment->createPayment` method
+- added gateway URL for UTF-8 data
 
 ## 0.1.0 Alpha 1
 ### Added

--- a/docs/request.md
+++ b/docs/request.md
@@ -16,6 +16,7 @@ $env = new TestEnvironment(
 );
 
 $env->setHashAlgorithm(TestEnvironment::HASH_SHA512); // if you want to use another algorithm than sha-1
+$env->setCharset(TestEnvironment::CHARSET_UTF_8); // if your application uses UTF-8 rather than ISO 8859-1
 
 // if you want, you can set this in the backoffice
 $env->setAcceptUrl("https://www.example.com/checkout/postfinance/accept");

--- a/docs/response.md
+++ b/docs/response.md
@@ -1,7 +1,7 @@
 # Transaction Feedback
 
-you can either get a transaction feedback with GET variables when user is redirecting back to your page or you can
-choose a server-side method. for both, you can use this code snippet to get the result of the transaction:
+You can either get a transaction feedback with GET variables when user is redirecting back to your page or you can
+choose a server-side method. For both, you can use this code snippet to get the result of the transaction:
 
 ```php
 <?php
@@ -19,6 +19,7 @@ $env = new TestEnvironment(
     "ABC" // SHA-OUT
 );
 $env->setHashAlgorithm(TestEnvironment::HASH_SHA512); // if you want to use another algorithm than sha-1
+$env->setCharset(TestEnvironment::CHARSET_UTF_8); // if your application uses UTF-8 rather than ISO 8859-1
 
 $ePayment = new PostFinanceEPayment($env);
 

--- a/src/whatwedo/PostFinanceEPayment/Environment/Environment.php
+++ b/src/whatwedo/PostFinanceEPayment/Environment/Environment.php
@@ -146,12 +146,11 @@ abstract class Environment implements EnvironmentInterface
         self::HASH_SHA512,
     );
 
-    public function __construct($pspid, $shaIn, $shaOut, $charset = self::CHARSET_ISO_8859_1)
+    public function __construct($pspid, $shaIn, $shaOut)
     {
         $this->setPSPID($pspid);
         $this->setShaIn($shaIn);
         $this->setShaOut($shaOut);
-        $this->setCharset($charset);
     }
 
     /**

--- a/src/whatwedo/PostFinanceEPayment/Environment/Environment.php
+++ b/src/whatwedo/PostFinanceEPayment/Environment/Environment.php
@@ -23,6 +23,9 @@ abstract class Environment implements EnvironmentInterface
     const HASH_SHA256 = "sha256";
     const HASH_SHA512 = "sha512";
 
+    const CHARSET_ISO_8859_1 = "iso_8859-1";
+    const CHARSET_UTF_8 = "utf-8";
+
     /**
      * @var string|null
      */
@@ -42,6 +45,11 @@ abstract class Environment implements EnvironmentInterface
      * @var string|null
      */
     protected $shaOut = null;
+
+    /**
+     * @var string client charset
+     */
+    protected static $CHARSET = self::CHARSET_ISO_8859_1;
 
     /**
      * @var string|null
@@ -138,11 +146,12 @@ abstract class Environment implements EnvironmentInterface
         self::HASH_SHA512,
     );
 
-    public function __construct($pspid, $shaIn, $shaOut)
+    public function __construct($pspid, $shaIn, $shaOut, $charset = self::CHARSET_ISO_8859_1)
     {
         $this->setPSPID($pspid);
         $this->setShaIn($shaIn);
         $this->setShaOut($shaOut);
+        $this->setCharset($charset);
     }
 
     /**
@@ -200,6 +209,28 @@ abstract class Environment implements EnvironmentInterface
     public function getShaOut()
     {
         return $this->shaOut;
+    }
+
+    /**
+     * Set charset
+     *
+     * @param string $charset
+     */
+    public function setCharset($charset)
+    {
+        self::$CHARSET = $charset;
+
+        return $this;
+    }
+
+    /**
+     * Get charset
+     *
+     * @return string
+     */
+    public function getCharset()
+    {
+        return $this->CHARSET;
     }
 
     /**

--- a/src/whatwedo/PostFinanceEPayment/Environment/Environment.php
+++ b/src/whatwedo/PostFinanceEPayment/Environment/Environment.php
@@ -146,6 +146,14 @@ abstract class Environment implements EnvironmentInterface
         self::HASH_SHA512,
     );
 
+    /**
+     * @var array allowed charsets
+     */
+    public static $ALLOWED_CHARSETS = array(
+        self::CHARSET_ISO_8859_1,
+        self::CHARSET_UTF_8,
+    );
+
     public function __construct($pspid, $shaIn, $shaOut)
     {
         $this->setPSPID($pspid);
@@ -217,6 +225,13 @@ abstract class Environment implements EnvironmentInterface
      */
     public function setCharset($charset)
     {
+        if (!in_array($charset, self::$ALLOWED_CHARSETS)) {
+            throw new InvalidArgumentException(sprintf(
+                "Invalid charset specified (%s), allowed: %s",
+                $charset,
+                implode(", ", self::ALLOWED_CHARSETS)
+            ));
+        }
         self::$CHARSET = $charset;
 
         return $this;
@@ -229,7 +244,7 @@ abstract class Environment implements EnvironmentInterface
      */
     public function getCharset()
     {
-        return $this->CHARSET;
+        return self::$CHARSET;
     }
 
     /**

--- a/src/whatwedo/PostFinanceEPayment/Environment/ProductionEnvironment.php
+++ b/src/whatwedo/PostFinanceEPayment/Environment/ProductionEnvironment.php
@@ -23,7 +23,13 @@ class ProductionEnvironment extends Environment
      */
     public static function getGatewayUrl()
     {
-        return self::BASE_URL . "/orderstandard.asp";
+        switch (self::$charset) {
+            case self::CHARSET_UTF_8:
+                return self::BASE_URL . "/orderstandard_utf8.asp";
+
+            default:
+                return self::BASE_URL . "/orderstandard.asp";
+        }
     }
 
     /**

--- a/src/whatwedo/PostFinanceEPayment/Environment/ProductionEnvironment.php
+++ b/src/whatwedo/PostFinanceEPayment/Environment/ProductionEnvironment.php
@@ -23,7 +23,7 @@ class ProductionEnvironment extends Environment
      */
     public static function getGatewayUrl()
     {
-        switch (self::$charset) {
+        switch (self::$CHARSET) {
             case self::CHARSET_UTF_8:
                 return self::BASE_URL . "/orderstandard_utf8.asp";
 

--- a/src/whatwedo/PostFinanceEPayment/Environment/TestEnvironment.php
+++ b/src/whatwedo/PostFinanceEPayment/Environment/TestEnvironment.php
@@ -23,7 +23,13 @@ class TestEnvironment extends Environment
      */
     public static function getGatewayUrl()
     {
-        return self::BASE_URL . "/orderstandard.asp";
+        switch (self::$charset) {
+            case self::CHARSET_UTF_8:
+                return self::BASE_URL . "/orderstandard_utf8.asp";
+
+            default:
+                return self::BASE_URL . "/orderstandard.asp";
+        }
     }
 
     /**

--- a/src/whatwedo/PostFinanceEPayment/Environment/TestEnvironment.php
+++ b/src/whatwedo/PostFinanceEPayment/Environment/TestEnvironment.php
@@ -23,7 +23,7 @@ class TestEnvironment extends Environment
      */
     public static function getGatewayUrl()
     {
-        switch (self::$charset) {
+        switch (self::$CHARSET) {
             case self::CHARSET_UTF_8:
                 return self::BASE_URL . "/orderstandard_utf8.asp";
 


### PR DESCRIPTION
PostFinance has two gateways depending on the charset, and the library would let connect to one of them only, which assumes ISO 8859-1. This commit should let access the gateway handling UTF-8.

Main changes are :
- addition of a new static `$CHARSET` property in the environment
- addition of the setters accordingly, with charset verification
- refactoring of the getGatewayUrl() accordingly

This has been made quickly and in order not to cause backwards compatibility, therefore the `$CHARSET` – used in the static `EnvironmentInterface::getGatewayUrl()` method – is static as well
