### PR TITLE
Fix wrong signature calculation if finalizeParameters is called twice

### DIFF
--- a/src/whatwedo/PostFinanceEPayment/Exception/InvalidCountryException.php
+++ b/src/whatwedo/PostFinanceEPayment/Exception/InvalidCountryException.php
@@ -19,11 +19,11 @@ class InvalidCountryException extends InvalidArgumentException
     /**
      * {@inheritdoc}
      */
-    public function __construct($inputCurrency, $allowedCurrencies = null)
+    public function __construct($inputCountry, $allowedCountries = null)
     {
         parent::__construct(sprintf(
-                'Invalid currency given (%s), must be an ISO-3166 Alpha 2 acronym',
-                $inputCurrency
+                'Invalid country given (%s), must be an ISO-3166 Alpha 2 acronym',
+                $inputCountry
             ));
     }
 }

--- a/src/whatwedo/PostFinanceEPayment/Payment/Payment.php
+++ b/src/whatwedo/PostFinanceEPayment/Payment/Payment.php
@@ -126,7 +126,9 @@ class Payment
      */
     private function finalizeParameters()
     {
-        $this->addSignature(); // adds the hashed signature
+        if (!$this->parameters->has(Parameter::SIGNATURE)) {
+            $this->addSignature(); // adds the hashed signature
+        }
 
         return $this;
     }


### PR DESCRIPTION
First of all, thanks for this great library! :)

I ran into a small issue accidentally, where my signature was not calculated correctly. If `Payment::finalizeParameters()` internally is called multiple times, the previous added signature parameter is reused for the new calculation of the signature. To me this happened because I was calling `Payment::getForm()` twice. Not really a bug, but maybe someone else saves some debugging time on this one.

Cheers