### PR TITLE
Add zip code parameter

### DIFF
--- a/src/whatwedo/PostFinanceEPayment/Client/AbstractClient.php
+++ b/src/whatwedo/PostFinanceEPayment/Client/AbstractClient.php
@@ -44,7 +44,12 @@ abstract class AbstractClient implements ClientInterface
     protected $address = null;
 
     /**
-     * @var string zip/city of the client
+     * @var string zip code of the client
+     */
+    protected $zip = null;
+
+    /**
+     * @var string city of the client
      */
     protected $town = null;
 
@@ -147,6 +152,26 @@ abstract class AbstractClient implements ClientInterface
     public function getAddress()
     {
         return $this->address;
+    }
+
+    /**
+     * @param string $zip
+     *
+     * @return AbstractClient
+     */
+    public function setZip($zip)
+    {
+        $this->zip = $zip;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getZip()
+    {
+        return $this->zip;
     }
 
     /**

--- a/src/whatwedo/PostFinanceEPayment/Client/ClientInterface.php
+++ b/src/whatwedo/PostFinanceEPayment/Client/ClientInterface.php
@@ -41,6 +41,11 @@ interface ClientInterface
     /**
      * @return string
      */
+    public function getZip();
+
+    /**
+     * @return string
+     */
     public function getTown();
 
     /**

--- a/src/whatwedo/PostFinanceEPayment/Model/Parameter.php
+++ b/src/whatwedo/PostFinanceEPayment/Model/Parameter.php
@@ -40,6 +40,7 @@ final class Parameter
     const CLIENT_NAME = 'CN';
     const CLIENT_EMAIL = 'EMAIL';
     const CLIENT_ADDRESS = 'OWNERADDRESS';
+    const CLIENT_ZIP = 'OWNERZIP';
     const CLIENT_TOWN = 'OWNERTOWN';
     const CLIENT_COUNTRY = 'OWNERCTY';
     const CLIENT_TEL = 'OWNERTELNO';

--- a/src/whatwedo/PostFinanceEPayment/Payment/Payment.php
+++ b/src/whatwedo/PostFinanceEPayment/Payment/Payment.php
@@ -82,6 +82,7 @@ class Payment
         $this->parameters->add(Parameter::LANGUAGE,         $this->client->getLocale());
         $this->parameters->add(Parameter::CLIENT_NAME,      $this->client->getName());
         $this->parameters->add(Parameter::CLIENT_ADDRESS,   $this->client->getAddress());
+        $this->parameters->add(Parameter::CLIENT_ZIP,       $this->client->getZip());
         $this->parameters->add(Parameter::CLIENT_TOWN,      $this->client->getTown());
         $this->parameters->add(Parameter::CLIENT_TEL,       $this->client->getTel());
         $this->parameters->add(Parameter::CLIENT_COUNTRY,   $this->client->getCountry());

--- a/src/whatwedo/PostFinanceEPayment/Payment/Payment.php
+++ b/src/whatwedo/PostFinanceEPayment/Payment/Payment.php
@@ -86,6 +86,7 @@ class Payment
         $this->parameters->add(Parameter::CLIENT_TEL,       $this->client->getTel());
         $this->parameters->add(Parameter::CLIENT_COUNTRY,   $this->client->getCountry());
         $this->parameters->add(Parameter::CLIENT_NAME,      $this->client->getName());
+        $this->parameters->add(Parameter::CLIENT_EMAIL,     $this->client->getEmail());
 
         // URL's
         $this->parameters->add(Parameter::HOME_URL,         $this->environment->getHomeUrl());

--- a/tests/whatwedo/PostFinanceEPayment/Tests/PostFinanceEPaymentTest.php
+++ b/tests/whatwedo/PostFinanceEPayment/Tests/PostFinanceEPaymentTest.php
@@ -77,6 +77,7 @@ class PostFinanceEPaymentTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($fields[Parameter::CLIENT_TOWN], $client->getTown());
         $this->assertEquals($fields[Parameter::CLIENT_TEL], $client->getTel());
         $this->assertEquals($fields[Parameter::CLIENT_COUNTRY], $client->getCountry());
+        $this->assertEquals($fields[Parameter::CLIENT_EMAIL], $client->getEmail());
     }
 
     public function testSignature()

--- a/tests/whatwedo/PostFinanceEPayment/Tests/PostFinanceEPaymentTest.php
+++ b/tests/whatwedo/PostFinanceEPayment/Tests/PostFinanceEPaymentTest.php
@@ -74,6 +74,7 @@ class PostFinanceEPaymentTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($fields[Parameter::LANGUAGE], $client->getLocale());
         $this->assertEquals($fields[Parameter::CARD_HOLDER], $client->getName());
         $this->assertEquals($fields[Parameter::CLIENT_ADDRESS], $client->getAddress());
+        $this->assertEquals($fields[Parameter::CLIENT_ZIP], $client->getZip());
         $this->assertEquals($fields[Parameter::CLIENT_TOWN], $client->getTown());
         $this->assertEquals($fields[Parameter::CLIENT_TEL], $client->getTel());
         $this->assertEquals($fields[Parameter::CLIENT_COUNTRY], $client->getCountry());
@@ -208,7 +209,8 @@ class PostFinanceEPaymentTest extends \PHPUnit\Framework\TestCase
         $client->setId($this->faker->numerify('####'))
             ->setName($this->faker->name)
             ->setAddress(sprintf('%s %s', $this->faker->streetName, $this->faker->numerify('##')))
-            ->setTown(sprintf('%s %s', $this->faker->postcode, $this->faker->city))
+            ->setZip($this->faker->postcode)
+            ->setTown($this->faker->city)
             ->setCountry('CH')
             ->setTel($this->faker->phoneNumber)
             ->setEmail($this->faker->email)


### PR DESCRIPTION
Extends the client object to accept a zip code beside the town/city. The zip code is sent to Postfinance via new parameter `OWNERZIP`.

Also fixes that the email parameter was not getting populated from the client object, when creating a payment.

PS. Thanks for this library! 👍 